### PR TITLE
[TOW-197][iOS][Main] Details > [<]이전버튼 tap 시 Main 하단이 잘려서 노출되는 현상

### DIFF
--- a/TodayWod/Features/Home/WorkOut/Completed/WorkoutCompletedFeature.swift
+++ b/TodayWod/Features/Home/WorkOut/Completed/WorkoutCompletedFeature.swift
@@ -14,9 +14,12 @@ struct WorkoutCompletedFeature {
     @ObservableState
     struct State: Equatable {
         let item: DayWorkoutModel
+        
+        @Shared(.inMemory("HideTabBar")) var hideTabBar: Bool = false
     }
     
     enum Action {
+        case onAppear
         case didTapCloseButton
     }
     
@@ -25,7 +28,11 @@ struct WorkoutCompletedFeature {
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .onAppear:
+                state.hideTabBar = true
+                return .none
             case .didTapCloseButton:
+                state.hideTabBar = false
                 return .run { _ in await dismiss() }
             }
         }
@@ -68,6 +75,9 @@ struct WorkoutCompletedView: View {
                     .padding(.horizontal, 38.0)
                 }
                 
+            }
+            .onAppear {
+                store.send(.onAppear)
             }
             .background(Colors.blue10.swiftUIColor)
             .toolbar(.hidden, for: .navigationBar)

--- a/TodayWod/Features/Home/WorkOut/Detail/WorkOutDetailFeature.swift
+++ b/TodayWod/Features/Home/WorkOut/Detail/WorkOutDetailFeature.swift
@@ -44,6 +44,7 @@ struct WorkOutDetailFeature {
     
     enum Action: BindableAction {
         case onAppear
+        case onDisappear
         case didEnterBackground
         case willEnterForeground
         case setWorkoutStates
@@ -95,12 +96,13 @@ struct WorkOutDetailFeature {
             case .onAppear:
                 state.hideTabBar = true
                 return .send(.setWorkoutStates)
+            case .onDisappear:
+                state.hideTabBar = false
+                return .run { _ in await dismiss() }
             case .didEnterBackground:
-                DLog.d("didEnterBackground")
                 return .merge(.send(.stopTimer),
                               .send(.pauseBreakTimer))
             case .willEnterForeground:
-                DLog.d("willEnterForeground")
                 return .merge(.send(.startTimer),
                               .send(.resumeBreakTimer))
             case .setWorkoutStates:
@@ -108,7 +110,7 @@ struct WorkOutDetailFeature {
                 state.workoutStates = IdentifiedArrayOf(uniqueElements: states)
                 return .none
             case .didTapBackButton:
-                return state.isDoneEnabled ? .send(.onConfirm(.quit)) : .run { _ in await dismiss() }
+                return state.isDoneEnabled ? .send(.onConfirm(.quit)) : .send(.onDisappear)
             case .didTapDoneButton:
                 return state.isDayCompleted ? .send(.doneWorkout) : .send(.onConfirm(.quit))
             case .didTapStartButton:

--- a/TodayWod/Features/Home/WorkOut/Detail/WorkOutDetailFeature.swift
+++ b/TodayWod/Features/Home/WorkOut/Detail/WorkOutDetailFeature.swift
@@ -44,7 +44,7 @@ struct WorkOutDetailFeature {
     
     enum Action: BindableAction {
         case onAppear
-        case onDisappear
+        case willDisappear
         case didEnterBackground
         case willEnterForeground
         case setWorkoutStates
@@ -96,7 +96,7 @@ struct WorkOutDetailFeature {
             case .onAppear:
                 state.hideTabBar = true
                 return .send(.setWorkoutStates)
-            case .onDisappear:
+            case .willDisappear:
                 state.hideTabBar = false
                 return .run { _ in await dismiss() }
             case .didEnterBackground:
@@ -110,7 +110,7 @@ struct WorkOutDetailFeature {
                 state.workoutStates = IdentifiedArrayOf(uniqueElements: states)
                 return .none
             case .didTapBackButton:
-                return state.isDoneEnabled ? .send(.onConfirm(.quit)) : .send(.onDisappear)
+                return state.isDoneEnabled ? .send(.onConfirm(.quit)) : .send(.willDisappear)
             case .didTapDoneButton:
                 return state.isDayCompleted ? .send(.doneWorkout) : .send(.onConfirm(.quit))
             case .didTapStartButton:

--- a/TodayWod/Features/Home/WorkOut/Detail/WorkOutDetailFeature.swift
+++ b/TodayWod/Features/Home/WorkOut/Detail/WorkOutDetailFeature.swift
@@ -26,7 +26,7 @@ struct WorkOutDetailFeature {
         var confirmationViewDynamicHeight: CGFloat = 0
         var breakTimerSettingsViewDynamicHeight: CGFloat = 0
 
-        @Shared(.inMemory("HideTabBar")) var hideTabBar: Bool = true
+        @Shared(.inMemory("HideTabBar")) var hideTabBar: Bool = false
         @Presents var confirmState: WorkoutConfirmationFeature.State?
         @Presents var breakTimerSettingsState: BreakTimerSettingsFeature.State?
         @Presents var alert: AlertState<Action.Alert>?

--- a/TodayWod/Features/Onboarding/Level/LevelSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Level/LevelSelectFeature.swift
@@ -22,12 +22,10 @@ struct LevelSelectFeature {
             self.entryType == .modify ? "확인" : "다음"
         }
 
-        @Shared(.inMemory("HideTabBar")) var hideTabBar: Bool = true
         @Shared(.appStorage("IsLaunchProgram")) var isLaunchProgram = false
     }
 
     enum Action {
-        case onAppear
         case didTapBackButton
         case didTapNextButton
         case setLevel(LevelType)
@@ -40,11 +38,6 @@ struct LevelSelectFeature {
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
-            case .onAppear:
-                if state.entryType == .modify {
-                    state.hideTabBar = true
-                }
-                return .none
             case .didTapBackButton:
                 return .run { _ in await dismiss() }
             case .didTapNextButton:
@@ -146,9 +139,6 @@ struct LevelSelectView: View {
                 }
             }
             .toolbar(.hidden, for: .navigationBar)
-            .onAppear {
-                store.send(.onAppear)
-            }
         }
     }
 

--- a/TodayWod/Features/Onboarding/Method/MethodSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Method/MethodSelectFeature.swift
@@ -22,14 +22,12 @@ struct MethodSelectFeature {
         }
 
         var dynamicHeight: CGFloat = .zero
-        @Shared(.inMemory("HideTabBar")) var hideTabBar: Bool = true
         @Shared(.appStorage("IsLaunchProgram")) var isLaunchProgram = false
 
         @Presents var methodDescription: MethodDescriptionFeature.State?
     }
 
     enum Action {
-        case onAppear
         case didTapBackButton
         case didTapStartButton
         case saveUserInfo
@@ -47,11 +45,6 @@ struct MethodSelectFeature {
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
-            case .onAppear:
-                if state.entryType == .modify {
-                    state.hideTabBar = true
-                }
-                return .none
             case .didTapBackButton:
                 return .run { _ in await dismiss() }
             case .didTapStartButton:
@@ -166,9 +159,6 @@ struct MethodSelectView: View {
                         .presentationDetents([.height(store.state.dynamicHeight + 20.0)])
 
                 }
-            }
-            .onAppear {
-                store.send(.onAppear)
             }
         }
     }

--- a/TodayWod/Features/Setting/MyPage/ModifyProfile/ModifyProfileFeature.swift
+++ b/TodayWod/Features/Setting/MyPage/ModifyProfile/ModifyProfileFeature.swift
@@ -19,8 +19,6 @@ struct ModifyProfileFeature {
         var focusedField: FieldType?
         var onboardingUserInfoModel: OnboardingUserInfoModel
         
-        @Shared(.inMemory("HideTabBar")) var hideTabBar: Bool = true
-        
         enum FieldType: Hashable {
             case nickName
         }
@@ -41,7 +39,6 @@ struct ModifyProfileFeature {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                state.hideTabBar = true
                 state.placeHolder = state.onboardingUserInfoModel.nickName ?? ""
                 state.focusedField = .nickName
                 return .none

--- a/TodayWod/Features/Setting/MyPage/ModifyWeight/ModifyWeightFeature.swift
+++ b/TodayWod/Features/Setting/MyPage/ModifyWeight/ModifyWeightFeature.swift
@@ -19,8 +19,6 @@ struct ModifyWeightFeature {
         var onboardingUserInfoModel = UserDefaultsManager().loadOnboardingUserInfo()
         var focusedField: FieldType?
         
-        @Shared(.inMemory("HideTabBar")) var hideTabBar: Bool = true
-        
         enum FieldType: Hashable {
             case weight
         }
@@ -41,7 +39,6 @@ struct ModifyWeightFeature {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                state.hideTabBar = true
                 state.placeHolder = String(state.onboardingUserInfoModel?.weight ?? 0)
                 state.focusedField = .weight
                 return .none

--- a/TodayWod/Features/Setting/MyPage/MyPageFeature.swift
+++ b/TodayWod/Features/Setting/MyPage/MyPageFeature.swift
@@ -37,6 +37,7 @@ struct MyPageFeature {
                 state.userInfoModel = onboardingUserInfoModel
                 return .none
             case .didTapBackButton:
+                state.hideTabBar = false
                 return .run { _ in await dismiss() }
             case .didTapModifyProfileButton:
                 return .none


### PR DESCRIPTION
- 화면 그린 후 TabBar 노출되어 Bottom이 TabBar가 아닌 SuperView Bottom으로 잡히는 현상
- 이전 화면을 닫으며 TabBar 노출 되도록 수정
- [추가 반영] 같은 현상이 Setting에서도 발생해서 반영 처리.

- [TOW-197](https://davidyoon1122.atlassian.net/browse/TOW-197?atlOrigin=eyJpIjoiMzgyYTlhZDQ4ZjNkNGQ4NWJlNTMyNmEwNGYwZGFlMmUiLCJwIjoiaiJ9)