### PR TITLE
[TOW-191] 레벨, 운동 방식 수정 시 기존 정보 선택 하지 못하도록 수정

### DIFF
--- a/TodayWod.xcodeproj/project.pbxproj
+++ b/TodayWod.xcodeproj/project.pbxproj
@@ -74,7 +74,7 @@
 		49101A7C2C8F3D3100FDB709 /* SocialLoginFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49101A7B2C8F3D3100FDB709 /* SocialLoginFeature.swift */; };
 		49101A802C9086B800FDB709 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49101A7F2C9086B800FDB709 /* UserDefaultsManager.swift */; };
 		49101A832C90878300FDB709 /* UserInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49101A822C90878300FDB709 /* UserInfoModel.swift */; };
-		494132A52CDEED9200EB5192 /* UserDefaultsAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494132A42CDEED9200EB5192 /* UserDefaultsAPIClient.swift */; };
+		494132A52CDEED9200EB5192 /* UserDefaultsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494132A42CDEED9200EB5192 /* UserDefaultsClient.swift */; };
 		49593C292C9570F4006105D1 /* Pretendard-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = 49593C202C9570F3006105D1 /* Pretendard-Thin.otf */; };
 		49593C2A2C9570F4006105D1 /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 49593C212C9570F3006105D1 /* Pretendard-Bold.otf */; };
 		49593C2B2C9570F4006105D1 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 49593C222C9570F4006105D1 /* Pretendard-Medium.otf */; };
@@ -216,7 +216,7 @@
 		49101A7B2C8F3D3100FDB709 /* SocialLoginFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginFeature.swift; sourceTree = "<group>"; };
 		49101A7F2C9086B800FDB709 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		49101A822C90878300FDB709 /* UserInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoModel.swift; sourceTree = "<group>"; };
-		494132A42CDEED9200EB5192 /* UserDefaultsAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsAPIClient.swift; sourceTree = "<group>"; };
+		494132A42CDEED9200EB5192 /* UserDefaultsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsClient.swift; sourceTree = "<group>"; };
 		49593C202C9570F3006105D1 /* Pretendard-Thin.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Thin.otf"; sourceTree = "<group>"; };
 		49593C212C9570F3006105D1 /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
 		49593C222C9570F4006105D1 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
@@ -383,7 +383,7 @@
 			isa = PBXGroup;
 			children = (
 				1C1D05072CBE2C1800BDA52D /* WodClient.swift */,
-				494132A42CDEED9200EB5192 /* UserDefaultsAPIClient.swift */,
+				494132A42CDEED9200EB5192 /* UserDefaultsClient.swift */,
 			);
 			path = StorageClient;
 			sourceTree = "<group>";
@@ -1152,7 +1152,7 @@
 				ADCEE10E2CBE202D00D71FEB /* ProgramRepository.swift in Sources */,
 				1CFED2D32C9B9C0D000A09E5 /* DayWorkoutTagType.swift in Sources */,
 				1C9C9F682CABA85900157001 /* Programs+Entity.swift in Sources */,
-				494132A52CDEED9200EB5192 /* UserDefaultsAPIClient.swift in Sources */,
+				494132A52CDEED9200EB5192 /* UserDefaultsClient.swift in Sources */,
 				1C5371F32CCF0DDC00EA4FB0 /* WorkoutDetailContentFeature.swift in Sources */,
 				1CFED2E32C9B9C9B000A09E5 /* WorkOutEmptyView.swift in Sources */,
 				ADC5B0642C93D4DC00E06C8E /* Fonts+Generated.swift in Sources */,

--- a/TodayWod.xcodeproj/project.pbxproj
+++ b/TodayWod.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		AD386C432CA66F460038C27F /* ModifyProfileFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD386C422CA66F460038C27F /* ModifyProfileFeature.swift */; };
 		AD386C462CA69B040038C27F /* ModifyWeightFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD386C452CA69B040038C27F /* ModifyWeightFeature.swift */; };
 		AD386C4A2CAA90ED0038C27F /* Extension+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD386C492CAA90ED0038C27F /* Extension+String.swift */; };
+		AD87AD092CE183F800D5EA6A /* UserDefaultsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD87AD082CE183F800D5EA6A /* UserDefaultsError.swift */; };
 		ADBACAA32C92D4BF00BED61C /* GenderSelectFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADBACAA22C92D4BF00BED61C /* GenderSelectFeature.swift */; };
 		ADC5B0582C92E04000E06C8E /* NicknameFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC5B0572C92E04000E06C8E /* NicknameFeature.swift */; };
 		ADC5B0642C93D4DC00E06C8E /* Fonts+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC5B0632C93D4DC00E06C8E /* Fonts+Generated.swift */; };
@@ -273,6 +274,7 @@
 		AD386C422CA66F460038C27F /* ModifyProfileFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyProfileFeature.swift; sourceTree = "<group>"; };
 		AD386C452CA69B040038C27F /* ModifyWeightFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyWeightFeature.swift; sourceTree = "<group>"; };
 		AD386C492CAA90ED0038C27F /* Extension+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+String.swift"; sourceTree = "<group>"; };
+		AD87AD082CE183F800D5EA6A /* UserDefaultsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsError.swift; sourceTree = "<group>"; };
 		ADBACAA22C92D4BF00BED61C /* GenderSelectFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenderSelectFeature.swift; sourceTree = "<group>"; };
 		ADC5B0572C92E04000E06C8E /* NicknameFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameFeature.swift; sourceTree = "<group>"; };
 		ADC5B0632C93D4DC00E06C8E /* Fonts+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Fonts+Generated.swift"; sourceTree = "<group>"; };
@@ -404,6 +406,7 @@
 			isa = PBXGroup;
 			children = (
 				49101A7F2C9086B800FDB709 /* UserDefaultsManager.swift */,
+				AD87AD082CE183F800D5EA6A /* UserDefaultsError.swift */,
 			);
 			path = UserDefaults;
 			sourceTree = "<group>";
@@ -1191,6 +1194,7 @@
 				4987120F2CA447C700FB876E /* CelebrateFeature.swift in Sources */,
 				49593C332C969126006105D1 /* CustomNavigationView.swift in Sources */,
 				497C0F092C9E466500F7444E /* TabMenuType.swift in Sources */,
+				AD87AD092CE183F800D5EA6A /* UserDefaultsError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TodayWod/Features/Home/WorkOut/Empty/WorkOutEmptyView.swift
+++ b/TodayWod/Features/Home/WorkOut/Empty/WorkOutEmptyView.swift
@@ -13,11 +13,12 @@ struct WorkOutEmptyFeature {
     
     @ObservableState
     struct State: Equatable {
-        let onboardingUserModel = UserDefaultsManager().loadOnboardingUserInfo()
+        var onboardingUserModel: OnboardingUserInfoModel?
         @Shared(.appStorage("IsLaunchProgram")) var isLaunchProgram = false
     }
     
     enum Action {
+        case onAppear
         case didTapStartButton
         case requestResult(Result<ProgramEntity, Error>)
         case setProgramResult(Result<ProgramModel, Error>)
@@ -25,10 +26,14 @@ struct WorkOutEmptyFeature {
 
     @Dependency(\.apiClient) var apiClient
     @Dependency(\.wodClient) var wodClient
+    @Dependency(\.userDefaultsAPIClient) var userDefaultsAPIClient
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .onAppear:
+                state.onboardingUserModel = userDefaultsAPIClient.loadOnboardingUserInfo()
+                return .none
             case .didTapStartButton:
                 guard let method = state.onboardingUserModel?.method,
                         let level = state.onboardingUserModel?.level else { return .none }
@@ -106,6 +111,9 @@ struct WorkOutEmptyView: View {
                 .padding(.top, 40.0)
                 
                 Spacer()
+            }
+            .onAppear {
+                store.send(.onAppear)
             }
         }
     }

--- a/TodayWod/Features/Home/WorkOut/Empty/WorkOutEmptyView.swift
+++ b/TodayWod/Features/Home/WorkOut/Empty/WorkOutEmptyView.swift
@@ -26,13 +26,13 @@ struct WorkOutEmptyFeature {
 
     @Dependency(\.apiClient) var apiClient
     @Dependency(\.wodClient) var wodClient
-    @Dependency(\.userDefaultsAPIClient) var userDefaultsAPIClient
+    @Dependency(\.userDefaultsClient) var userDefaultsClient
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                state.onboardingUserModel = userDefaultsAPIClient.loadOnboardingUserInfo()
+                state.onboardingUserModel = userDefaultsClient.loadOnboardingUserInfo()
                 return .none
             case .didTapStartButton:
                 guard let method = state.onboardingUserModel?.method,

--- a/TodayWod/Features/Onboarding/Height/HeightInputFeature.swift
+++ b/TodayWod/Features/Onboarding/Height/HeightInputFeature.swift
@@ -16,7 +16,7 @@ struct HeightInputFeature {
         var height: String = ""
         var onboardingUserModel: OnboardingUserInfoModel
 
-        var isValidHeight: Bool = false
+        var isButtonEnabled: Bool = false
         var focusedField: FieldType?
 
         enum FieldType: Hashable {
@@ -56,7 +56,7 @@ struct HeightInputFeature {
                 return .send(.finishInputHeight(WeightInputFeature.State(onboardingUserModel: state.onboardingUserModel)))
             case let .setHeight(height):
                 state.height = height
-                state.isValidHeight = state.height.isValidHeightWeight()
+                state.isButtonEnabled = state.height.isValidHeightWeight()
                 return .none
             case .finishInputHeight:
                 return .none
@@ -132,7 +132,7 @@ struct HeightInputView: View {
                 BottomButton(title: Constants.buttonTitle) {
                     store.send(.didTapNextButton)
                 }
-                .disabled(!store.isValidHeight)
+                .disabled(!store.isButtonEnabled)
                 .padding(.bottom, 20.0)
                 .padding(.horizontal, 38.0)
             }

--- a/TodayWod/Features/Onboarding/Level/LevelSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Level/LevelSelectFeature.swift
@@ -38,7 +38,8 @@ struct LevelSelectFeature {
         case finishInputLevel(MethodSelectFeature.State)
         case saveData(LevelType)
         case alert(PresentationAction<Alert>)
-        
+        case reloadUserInfo
+
         @CasePathable
         enum Alert: Equatable {
             case resetLevel
@@ -54,7 +55,15 @@ struct LevelSelectFeature {
             switch action {
             case .onAppear:
                 state.level = state.onboardingUserModel.level
-                state.isValidLevel = state.level != nil
+                switch state.entryType {
+                case .onBoarding:
+                    state.isValidLevel = state.level != nil
+                case .modify:
+                    if let savedData = userDefaultsAPIClient.loadOnboardingUserInfo() {
+                        state.isValidLevel = savedData.level != state.level && state.level != nil
+                    }
+                }
+
                 return .none
             case .didTapBackButton:
                 if let level = state.level {
@@ -84,7 +93,7 @@ struct LevelSelectFeature {
                 } message: {
                     TextState("새로운 수준과 방식에 맞게\n운동 루틴이 초기화돼요")
                 }
-                return .none
+                return .send(.reloadUserInfo)
             case .alert(.presented(.resetLevel)):
                 guard var onboardingUserModel = userDefaultsClient.loadOnboardingUserInfo() else { return .none }
                 onboardingUserModel.level = state.level
@@ -102,15 +111,26 @@ struct LevelSelectFeature {
                 generator.prepare()
                 generator.impactOccurred()
                 state.level = level
-                if state.level != nil {
-                    state.isValidLevel = true
+
+                switch state.entryType {
+                case .onBoarding:
+                    if state.level != nil {
+                        state.isValidLevel = true
+                    }
+                case .modify:
+                    if let savedData = userDefaultsAPIClient.loadOnboardingUserInfo() {
+                        state.isValidLevel = savedData.level != state.level && state.level != nil
+                    }
                 }
+
                 return .none
             case .finishInputLevel:
                 return .none
             case .alert:
                 return .none
             case .saveData:
+                return .none
+            case .reloadUserInfo:
                 return .none
             }
         }

--- a/TodayWod/Features/Onboarding/Level/LevelSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Level/LevelSelectFeature.swift
@@ -16,7 +16,7 @@ struct LevelSelectFeature {
         var level: LevelType? = nil
         var onboardingUserModel: OnboardingUserInfoModel
 
-        var isValidLevel: Bool = false
+        var isButtonEnabled: Bool = false
         var entryType: EntryType = .onBoarding
         var buttonTitle: String {
             self.entryType == .modify ? "확인" : "다음"
@@ -57,10 +57,10 @@ struct LevelSelectFeature {
                 state.level = state.onboardingUserModel.level
                 switch state.entryType {
                 case .onBoarding:
-                    state.isValidLevel = state.level != nil
+                    state.isButtonEnabled = state.level != nil
                 case .modify:
-                    if let savedData = userDefaultsClient.loadOnboardingUserInfo() {
-                        state.isValidLevel = savedData.level != state.level && state.level != nil
+                    if state.level != nil, let savedData = userDefaultsClient.loadOnboardingUserInfo() {
+                        state.isButtonEnabled = savedData.level != state.level
                     }
                 }
 
@@ -115,11 +115,11 @@ struct LevelSelectFeature {
                 switch state.entryType {
                 case .onBoarding:
                     if state.level != nil {
-                        state.isValidLevel = true
+                        state.isButtonEnabled = true
                     }
                 case .modify:
-                    if let savedData = userDefaultsClient.loadOnboardingUserInfo() {
-                        state.isValidLevel = savedData.level != state.level && state.level != nil
+                    if state.level != nil, let savedData = userDefaultsClient.loadOnboardingUserInfo() {
+                        state.isButtonEnabled = savedData.level != state.level
                     }
                 }
 
@@ -195,7 +195,7 @@ struct LevelSelectView: View {
                         BottomButton(title: store.state.buttonTitle) {
                             store.send(.didTapNextButton)
                         }
-                        .disabled(!store.isValidLevel)
+                        .disabled(!store.isButtonEnabled)
                         .padding(.bottom, 20.0)
                         .padding(.horizontal, 38.0)
                     }

--- a/TodayWod/Features/Onboarding/Level/LevelSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Level/LevelSelectFeature.swift
@@ -47,7 +47,7 @@ struct LevelSelectFeature {
 
     @Dependency(\.dismiss) var dismiss
     @Dependency(\.wodClient) var wodClient
-    @Dependency(\.userDefaultsAPIClient) var userDefaultsAPIClient
+    @Dependency(\.userDefaultsClient) var userDefaultsClient
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -86,9 +86,9 @@ struct LevelSelectFeature {
                 }
                 return .none
             case .alert(.presented(.resetLevel)):
-                guard var onboardingUserModel = userDefaultsAPIClient.loadOnboardingUserInfo() else { return .none }
+                guard var onboardingUserModel = userDefaultsClient.loadOnboardingUserInfo() else { return .none }
                 onboardingUserModel.level = state.level
-                userDefaultsAPIClient.saveOnboardingUserInfo(onboardingUserModel)
+                userDefaultsClient.saveOnboardingUserInfo(onboardingUserModel)
 
                 state.isLaunchProgram = false
                 state.onCelebrate = false

--- a/TodayWod/Features/Onboarding/Level/LevelSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Level/LevelSelectFeature.swift
@@ -59,7 +59,7 @@ struct LevelSelectFeature {
                 case .onBoarding:
                     state.isValidLevel = state.level != nil
                 case .modify:
-                    if let savedData = userDefaultsAPIClient.loadOnboardingUserInfo() {
+                    if let savedData = userDefaultsClient.loadOnboardingUserInfo() {
                         state.isValidLevel = savedData.level != state.level && state.level != nil
                     }
                 }
@@ -118,7 +118,7 @@ struct LevelSelectFeature {
                         state.isValidLevel = true
                     }
                 case .modify:
-                    if let savedData = userDefaultsAPIClient.loadOnboardingUserInfo() {
+                    if let savedData = userDefaultsClient.loadOnboardingUserInfo() {
                         state.isValidLevel = savedData.level != state.level && state.level != nil
                     }
                 }

--- a/TodayWod/Features/Onboarding/Method/MethodSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Method/MethodSelectFeature.swift
@@ -13,7 +13,7 @@ struct MethodSelectFeature {
 
     @ObservableState
     struct State: Equatable {
-        var isValidMethod: Bool = false
+        var isButtonEnabled: Bool = false
         var methodType: ProgramMethodType? = nil
         var onboardingUserModel: OnboardingUserInfoModel
         var entryType: EntryType = .onBoarding
@@ -62,10 +62,10 @@ struct MethodSelectFeature {
                 switch state.entryType {
 
                 case .onBoarding:
-                    state.isValidMethod = state.methodType != nil
+                    state.isButtonEnabled = state.methodType != nil
                 case .modify:
-                    if let savedData = userDefaultsClient.loadOnboardingUserInfo() {
-                        state.isValidMethod = savedData.method != state.methodType && state.methodType != nil
+                    if state.methodType != nil, let savedData = userDefaultsClient.loadOnboardingUserInfo() {
+                        state.isButtonEnabled = savedData.method != state.methodType
                     }
                 }
 
@@ -120,10 +120,10 @@ struct MethodSelectFeature {
                 switch state.entryType {
 
                 case .onBoarding:
-                    state.isValidMethod = state.methodType != nil
+                    state.isButtonEnabled = state.methodType != nil
                 case .modify:
-                    if let savedData = userDefaultsClient.loadOnboardingUserInfo() {
-                        state.isValidMethod = savedData.method != state.methodType && state.methodType != nil
+                    if state.methodType != nil, let savedData = userDefaultsClient.loadOnboardingUserInfo() {
+                        state.isButtonEnabled = savedData.method != state.methodType
                     }
                 }
 
@@ -197,7 +197,7 @@ struct MethodSelectView: View {
                     BottomButton(title: store.state.buttonTitle) {
                         store.send(.didTapStartButton)
                     }
-                    .disabled(!store.isValidMethod)
+                    .disabled(!store.isButtonEnabled)
                     .padding(.bottom, 20.0)
                     .padding(.horizontal, 38.0)
                 }

--- a/TodayWod/Features/Onboarding/Method/MethodSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Method/MethodSelectFeature.swift
@@ -52,7 +52,7 @@ struct MethodSelectFeature {
 
     @Dependency(\.dismiss) var dismiss
     @Dependency(\.wodClient) var wodClient
-    @Dependency(\.userDefaultsAPIClient) var userDefaultsAPIClient
+    @Dependency(\.userDefaultsClient) var userDefaultsClient
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -73,7 +73,7 @@ struct MethodSelectFeature {
             case .didTapStartButton:
                 return state.entryType == .onBoarding ? .send(.saveUserInfo) : .send(.onConfirmAlert)
             case .saveUserInfo:
-                userDefaultsAPIClient.saveOnboardingUserInfo(state.onboardingUserModel)
+                userDefaultsClient.saveOnboardingUserInfo(state.onboardingUserModel)
                 return .send(.finishOnboarding)
             case .onConfirmAlert:
                 state.alert = AlertState {
@@ -90,9 +90,9 @@ struct MethodSelectFeature {
                 }
                 return .none
             case .alert(.presented(.resetMethod)):
-                guard var onboadingUserModel = userDefaultsAPIClient.loadOnboardingUserInfo() else { return .none }
+                guard var onboadingUserModel = userDefaultsClient.loadOnboardingUserInfo() else { return .none }
                 onboadingUserModel.method = state.methodType
-                userDefaultsAPIClient.saveOnboardingUserInfo(onboadingUserModel)
+                userDefaultsClient.saveOnboardingUserInfo(onboadingUserModel)
 
                 state.isLaunchProgram = false
                 state.onCelebrate = false

--- a/TodayWod/Features/Onboarding/Method/MethodSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Method/MethodSelectFeature.swift
@@ -64,7 +64,7 @@ struct MethodSelectFeature {
                 case .onBoarding:
                     state.isValidMethod = state.methodType != nil
                 case .modify:
-                    if let savedData = userDefaultsAPIClient.loadOnboardingUserInfo() {
+                    if let savedData = userDefaultsClient.loadOnboardingUserInfo() {
                         state.isValidMethod = savedData.method != state.methodType && state.methodType != nil
                     }
                 }
@@ -122,7 +122,7 @@ struct MethodSelectFeature {
                 case .onBoarding:
                     state.isValidMethod = state.methodType != nil
                 case .modify:
-                    if let savedData = userDefaultsAPIClient.loadOnboardingUserInfo() {
+                    if let savedData = userDefaultsClient.loadOnboardingUserInfo() {
                         state.isValidMethod = savedData.method != state.methodType && state.methodType != nil
                     }
                 }

--- a/TodayWod/Features/Onboarding/Method/MethodSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Method/MethodSelectFeature.swift
@@ -59,7 +59,16 @@ struct MethodSelectFeature {
             switch action {
             case .onAppear:
                 state.methodType = state.onboardingUserModel.method
-                state.isValidMethod = state.methodType != nil
+                switch state.entryType {
+
+                case .onBoarding:
+                    state.isValidMethod = state.methodType != nil
+                case .modify:
+                    if let savedData = userDefaultsAPIClient.loadOnboardingUserInfo() {
+                        state.isValidMethod = savedData.method != state.methodType && state.methodType != nil
+                    }
+                }
+
                 return .none
             case .didTapBackButton:
                 if let method = state.methodType {
@@ -108,8 +117,14 @@ struct MethodSelectFeature {
                 generator.prepare()
                 generator.impactOccurred()
 
-                if let _ = state.methodType {
-                    state.isValidMethod = true
+                switch state.entryType {
+
+                case .onBoarding:
+                    state.isValidMethod = state.methodType != nil
+                case .modify:
+                    if let savedData = userDefaultsAPIClient.loadOnboardingUserInfo() {
+                        state.isValidMethod = savedData.method != state.methodType && state.methodType != nil
+                    }
                 }
 
                 return .none

--- a/TodayWod/Features/Onboarding/Nickname/NicknameFeature.swift
+++ b/TodayWod/Features/Onboarding/Nickname/NicknameFeature.swift
@@ -20,7 +20,7 @@ struct NicknameFeature {
         let validNicknameMessage: String = "멋진 닉네임이에요!"
         let buttonTitle: String = "다음"
         var nickName: String = ""
-        var isValidNickname: Bool = false
+        var isButtonEnabled: Bool = false
         var onboardingUserModel: OnboardingUserInfoModel
         var focusedField: FieldType?
 
@@ -51,7 +51,7 @@ struct NicknameFeature {
                 return .none
             case let .setNickname(nickName):
                 state.nickName = nickName
-                state.isValidNickname = nickName.isValidNickName()
+                state.isButtonEnabled = nickName.isValidNickName()
                 return .none
             case .didTapNextButton:
                 state.onboardingUserModel.nickName = state.nickName
@@ -127,10 +127,10 @@ struct NicknameInputView: View {
                         .padding(.horizontal, 20.0)
                         
                         HStack {
-                            Text(store.isValidNickname ? store.validNicknameMessage : store.ruleDescription)
+                            Text(store.isButtonEnabled ? store.validNicknameMessage : store.ruleDescription)
                                 .multilineTextAlignment(.center)
                                 .font(Fonts.Pretendard.regular.swiftUIFont(size: 13.0))
-                                .foregroundStyle(store.isValidNickname ? Colors.green10.swiftUIColor : .grey80)
+                                .foregroundStyle(store.isButtonEnabled ? Colors.green10.swiftUIColor : .grey80)
                         }
                     }
                 }
@@ -138,7 +138,7 @@ struct NicknameInputView: View {
                 BottomButton(title: store.buttonTitle) {
                     store.send(.didTapNextButton)
                 }
-                .disabled(!store.isValidNickname)
+                .disabled(!store.isButtonEnabled)
                 .padding(.bottom, 20.0)
                 .padding(.horizontal, 38.0)
             }

--- a/TodayWod/Features/Onboarding/Weight/WeightInputFeature.swift
+++ b/TodayWod/Features/Onboarding/Weight/WeightInputFeature.swift
@@ -17,7 +17,7 @@ struct WeightInputFeature {
         var onboardingUserModel: OnboardingUserInfoModel
         var focusedField: FieldType?
 
-        var isValidWeight: Bool = false
+        var isButtonEnabled: Bool = false
 
         enum FieldType: Hashable {
             case weight
@@ -56,7 +56,7 @@ struct WeightInputFeature {
                 return .send(.finishInputWeight(LevelSelectFeature.State(onboardingUserModel: state.onboardingUserModel)))
             case let .setWeight(weight):
                 state.weight = weight
-                state.isValidWeight = state.weight.isValidHeightWeight()
+                state.isButtonEnabled = state.weight.isValidHeightWeight()
                 return .none
             case .finishInputWeight:
                 return .none
@@ -133,7 +133,7 @@ struct WeightInputView: View {
                 BottomButton(title: Constants.buttonTitle) {
                     store.send(.didTapNextButton)
                 }
-                .disabled(!store.isValidWeight)
+                .disabled(!store.isButtonEnabled)
                 .padding(.bottom, 20.0)
                 .padding(.horizontal, 38.0)
             }

--- a/TodayWod/Features/Root/TodayWod.swift
+++ b/TodayWod/Features/Root/TodayWod.swift
@@ -23,14 +23,14 @@ struct TodayWod {
         case onBoarding(GenderSelectFeature.Action)
     }
 
-    @Dependency(\.userDefaultsAPIClient) var userDefaultsAPIClient
+    @Dependency(\.userDefaultsClient) var userDefaultsClient
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case .splash(.finishSplash):
 
-                if userDefaultsAPIClient.checkUserInfoExists() {
+                if userDefaultsClient.checkUserInfoExists() {
                     state = .app(AppFeature.State())
                 } else {
                     state = .onBoarding(GenderSelectFeature.State())

--- a/TodayWod/Features/Setting/MyPage/ModifyProfile/ModifyProfileFeature.swift
+++ b/TodayWod/Features/Setting/MyPage/ModifyProfile/ModifyProfileFeature.swift
@@ -15,7 +15,7 @@ struct ModifyProfileFeature {
     struct State: Equatable {
         var placeHolder: String = ""
         var nickName: String = ""
-        var isValidNickname: Bool = false
+        var isButtonEnabled: Bool = false
         var focusedField: FieldType?
         var onboardingUserInfoModel: OnboardingUserInfoModel
         
@@ -54,7 +54,7 @@ struct ModifyProfileFeature {
             case let .setNickname(nickname):
                 state.nickName = nickname
                 state.onboardingUserInfoModel.nickName = nickname
-                state.isValidNickname = nickname.isValidNickName()
+                state.isButtonEnabled = nickname.isValidNickName()
                 return .none
             }
         }
@@ -92,10 +92,10 @@ struct ModifyProfileView: View {
                     .padding(.horizontal, 20.0)
                     
                     HStack {
-                        Text(store.isValidNickname ? Constants.validNicknameMessage : Constants.ruleDescription)
+                        Text(store.isButtonEnabled ? Constants.validNicknameMessage : Constants.ruleDescription)
                             .multilineTextAlignment(.center)
                             .font(Fonts.Pretendard.regular.swiftUIFont(size: 13.0))
-                            .foregroundStyle(store.isValidNickname ? Colors.green10.swiftUIColor : .grey80)
+                            .foregroundStyle(store.isButtonEnabled ? Colors.green10.swiftUIColor : .grey80)
                     }
                     .padding(.top, 8.0)
                 }
@@ -105,7 +105,7 @@ struct ModifyProfileView: View {
                 BottomButton(title: Constants.buttonTitle) {
                     store.send(.didTapConfirmButton)
                 }
-                .disabled(!store.isValidNickname)
+                .disabled(!store.isButtonEnabled)
                 .padding(.horizontal, 38.0)
                 .padding(.bottom, 20.0)
             }

--- a/TodayWod/Features/Setting/MyPage/ModifyProfile/ModifyProfileFeature.swift
+++ b/TodayWod/Features/Setting/MyPage/ModifyProfile/ModifyProfileFeature.swift
@@ -33,7 +33,8 @@ struct ModifyProfileFeature {
     }
     
     @Dependency(\.dismiss) var dismiss
-    
+    @Dependency(\.userDefaultsAPIClient) var userDefaultsAPIClient
+
     var body: some ReducerOf<Self> {
         BindingReducer()
         Reduce { state, action in
@@ -45,8 +46,8 @@ struct ModifyProfileFeature {
             case .didTapBackButton:
                 return .run { _ in await dismiss() }
             case .didTapConfirmButton:
-                UserDefaultsManager().saveOnboardingUserInfo(data: state.onboardingUserInfoModel)
-                
+                userDefaultsAPIClient.saveOnboardingUserInfo(state.onboardingUserInfoModel)
+
                 return .run { _ in await dismiss() }
             case .binding:
                 return .none

--- a/TodayWod/Features/Setting/MyPage/ModifyProfile/ModifyProfileFeature.swift
+++ b/TodayWod/Features/Setting/MyPage/ModifyProfile/ModifyProfileFeature.swift
@@ -33,7 +33,7 @@ struct ModifyProfileFeature {
     }
     
     @Dependency(\.dismiss) var dismiss
-    @Dependency(\.userDefaultsAPIClient) var userDefaultsAPIClient
+    @Dependency(\.userDefaultsClient) var userDefaultsClient
 
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -46,7 +46,7 @@ struct ModifyProfileFeature {
             case .didTapBackButton:
                 return .run { _ in await dismiss() }
             case .didTapConfirmButton:
-                userDefaultsAPIClient.saveOnboardingUserInfo(state.onboardingUserInfoModel)
+                userDefaultsClient.saveOnboardingUserInfo(state.onboardingUserInfoModel)
 
                 return .run { _ in await dismiss() }
             case .binding:

--- a/TodayWod/Features/Setting/MyPage/ModifyWeight/ModifyWeightFeature.swift
+++ b/TodayWod/Features/Setting/MyPage/ModifyWeight/ModifyWeightFeature.swift
@@ -15,7 +15,7 @@ struct ModifyWeightFeature {
     struct State: Equatable {
         var placeHolder: String = "0"
         var weight: String = ""
-        var isValidWeight: Bool = false
+        var isButtonEnabled: Bool = false
         var focusedField: FieldType?
         
         enum FieldType: Hashable {
@@ -46,7 +46,7 @@ struct ModifyWeightFeature {
                 return .none
             case let .setWeight(weight):
                 state.weight = weight
-                state.isValidWeight = state.weight.isValidHeightWeight()
+                state.isButtonEnabled = state.weight.isValidHeightWeight()
                 
                 return .none
             case .binding:
@@ -104,7 +104,7 @@ struct ModifyWeightView: View {
                 BottomButton(title: Constants.buttonTitle) {
                     store.send(.didTapConfirmButton)
                 }
-                .disabled(!store.isValidWeight)
+                .disabled(!store.isButtonEnabled)
                 .padding(.horizontal, 38.0)
                 .padding(.bottom, 20.0)
             }

--- a/TodayWod/Features/Setting/MyPage/ModifyWeight/ModifyWeightFeature.swift
+++ b/TodayWod/Features/Setting/MyPage/ModifyWeight/ModifyWeightFeature.swift
@@ -32,14 +32,14 @@ struct ModifyWeightFeature {
     }
     
     @Dependency(\.dismiss) var dismiss
-    @Dependency(\.userDefaultsAPIClient) var userDefaultsAPIClient
+    @Dependency(\.userDefaultsClient) var userDefaultsClient
 
     var body: some ReducerOf<Self> {
         BindingReducer()
         Reduce { state, action in
             switch action {
             case .onAppear:
-                if let onboardingUserInfoModel = userDefaultsAPIClient.loadOnboardingUserInfo() {
+                if let onboardingUserInfoModel = userDefaultsClient.loadOnboardingUserInfo() {
                     state.placeHolder = String(onboardingUserInfoModel.weight ?? 0)
                 }
                 state.focusedField = .weight
@@ -54,9 +54,9 @@ struct ModifyWeightFeature {
             case .didTapBackButton:
                 return .run { _ in await dismiss() }
             case .didTapConfirmButton:
-                guard var onboardingUserInfoModel = userDefaultsAPIClient.loadOnboardingUserInfo() else { return .none }
+                guard var onboardingUserInfoModel = userDefaultsClient.loadOnboardingUserInfo() else { return .none }
                 onboardingUserInfoModel.weight = Int(state.weight)
-                userDefaultsAPIClient.saveOnboardingUserInfo(onboardingUserInfoModel)
+                userDefaultsClient.saveOnboardingUserInfo(onboardingUserInfoModel)
 
                 return .run { _ in await dismiss() }
             }

--- a/TodayWod/Features/Setting/MyPage/MyInfo/MyInfoView.swift
+++ b/TodayWod/Features/Setting/MyPage/MyInfo/MyInfoView.swift
@@ -45,7 +45,7 @@ private extension MyInfoView {
 }
 
 #Preview {
-    MyInfoView(store: Store(initialState: MyPageFeature.State()) {
+    MyInfoView(store: Store(initialState: MyPageFeature.State(onboardingUserInfoModel: .preview)) {
         MyPageFeature()
     }, userInfo: OnboardingUserInfoModel.preview.convertToSubArray())
 }

--- a/TodayWod/Features/Setting/MyPage/MyPageFeature.swift
+++ b/TodayWod/Features/Setting/MyPage/MyPageFeature.swift
@@ -32,13 +32,13 @@ struct MyPageFeature {
     }
     
     @Dependency(\.dismiss) var dismiss
-    @Dependency(\.userDefaultsAPIClient) var userDefaultsAPIClient
+    @Dependency(\.userDefaultsClient) var userDefaultsClient
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                if let onboardingUserInfoModel = userDefaultsAPIClient.loadOnboardingUserInfo() {
+                if let onboardingUserInfoModel = userDefaultsClient.loadOnboardingUserInfo() {
                     state.onboardingUserInfoModel = onboardingUserInfoModel
                 }
                 state.hideTabBar = true

--- a/TodayWod/Features/Setting/MyPage/MyPageFeature.swift
+++ b/TodayWod/Features/Setting/MyPage/MyPageFeature.swift
@@ -13,28 +13,35 @@ struct MyPageFeature {
     
     @ObservableState
     struct State: Equatable {
-        var userInfoModel = UserDefaultsManager().loadOnboardingUserInfo() ?? .preview
         let version: String = AppEnvironment.shortVersion
-        
+
         @Shared(.inMemory("HideTabBar")) var hideTabBar: Bool = true
+
+        var onboardingUserInfoModel: OnboardingUserInfoModel
+
+        init(onboardingUserInfoModel: OnboardingUserInfoModel) {
+            self.onboardingUserInfoModel = onboardingUserInfoModel
+        }
     }
 
     enum Action {
         case onAppear
         case didTapBackButton
-        case didTapModifyProfileButton(OnboardingUserInfoModel)
+        case didTapModifyProfileButton(OnboardingUserInfoModel?)
         case didTapInfoButton(UserInfoType)
     }
     
     @Dependency(\.dismiss) var dismiss
-    
+    @Dependency(\.userDefaultsAPIClient) var userDefaultsAPIClient
+
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case .onAppear:
+                if let onboardingUserInfoModel = userDefaultsAPIClient.loadOnboardingUserInfo() {
+                    state.onboardingUserInfoModel = onboardingUserInfoModel
+                }
                 state.hideTabBar = true
-                guard let onboardingUserInfoModel = UserDefaultsManager().loadOnboardingUserInfo() else { return .none }
-                state.userInfoModel = onboardingUserInfoModel
                 return .none
             case .didTapBackButton:
                 state.hideTabBar = false
@@ -62,11 +69,11 @@ struct MyPageView: View {
                 }
                 ScrollView {
                     LazyVStack {
-                        ProfileView(nickName: store.userInfoModel.nickName ?? "", gender: store.userInfoModel.gender ?? .man) {
-                            store.send(.didTapModifyProfileButton(store.state.userInfoModel))
+                        ProfileView(nickName: store.onboardingUserInfoModel.nickName ?? "", gender: store.onboardingUserInfoModel.gender ?? .man) {
+                            store.send(.didTapModifyProfileButton(store.state.onboardingUserInfoModel))
                         }
                         CustomDivider(color: .grey20, size: 5, direction: .horizontal)
-                        MyInfoView(store: store, userInfo: store.userInfoModel.convertToSubArray())
+                        MyInfoView(store: store, userInfo: store.onboardingUserInfoModel.convertToSubArray())
                         CustomDivider(color: .grey20, size: 5, direction: .horizontal)
                         VersionInfoView(version: store.version)
                     }
@@ -83,7 +90,7 @@ struct MyPageView: View {
 }
 
 #Preview {
-    MyPageView(store: Store(initialState: MyPageFeature.State()) {
+    MyPageView(store: Store(initialState: MyPageFeature.State(onboardingUserInfoModel: .preview)) {
         MyPageFeature()
     })
 }

--- a/TodayWod/Features/Setting/SettingFeature.swift
+++ b/TodayWod/Features/Setting/SettingFeature.swift
@@ -32,7 +32,7 @@ struct SettingFeature {
     }
     
     @Dependency(\.wodClient) var wodClient
-    @Dependency(\.userDefaultsAPIClient) var userDefaultsAPIClient
+    @Dependency(\.userDefaultsClient) var userDefaultsClient
 
     enum Action: BindableAction {
         case onAppear
@@ -99,12 +99,12 @@ struct SettingFeature {
                         state.path.append(.modifyWeight(ModifyWeightFeature.State()))
                         return .none
                     case .level:
-                        if let onboardingUserInfoModel = userDefaultsAPIClient.loadOnboardingUserInfo() {
+                        if let onboardingUserInfoModel = userDefaultsClient.loadOnboardingUserInfo() {
                             state.path.append(.modifyLevel(LevelSelectFeature.State(onboardingUserModel: onboardingUserInfoModel, entryType: .modify)))
                         }
                         return .none
                     case .method:
-                        if let onboardingUserInfoModel = userDefaultsAPIClient.loadOnboardingUserInfo() {
+                        if let onboardingUserInfoModel = userDefaultsClient.loadOnboardingUserInfo() {
                             state.path.append(.modifyMethod(MethodSelectFeature.State(onboardingUserModel: onboardingUserInfoModel, entryType: .modify)))
                         }
                         return .none
@@ -124,7 +124,7 @@ struct SettingFeature {
                 return .none
             case .loadUserDefault:
                 return .run { send in
-                    if let result = userDefaultsAPIClient.loadOnboardingUserInfo() {
+                    if let result = userDefaultsClient.loadOnboardingUserInfo() {
                         await send(.loadUserDefaultResult(.success(result)))
                     } else {
                         await send(.loadUserDefaultResult(.failure(UserDefaultsError.emptyData)))

--- a/TodayWod/Features/Setting/SettingFeature.swift
+++ b/TodayWod/Features/Setting/SettingFeature.swift
@@ -22,7 +22,7 @@ struct SettingFeature {
 
     @ObservableState
     struct State: Equatable {
-        var onboardingUserInfoModel: OnboardingUserInfoModel? = UserDefaultsManager().loadOnboardingUserInfo()
+        var onboardingUserInfoModel: OnboardingUserInfoModel?
         var recentDayWorkouts: [DayWorkoutModel] = []
         var completedDates: Set<Date> = []
         var path = StackState<Path.State>()
@@ -32,6 +32,7 @@ struct SettingFeature {
     }
     
     @Dependency(\.wodClient) var wodClient
+    @Dependency(\.userDefaultsAPIClient) var userDefaultsAPIClient
 
     enum Action: BindableAction {
         case onAppear
@@ -44,6 +45,8 @@ struct SettingFeature {
         case didTapMyActivity(DayWorkoutModel)
         case completedAction(PresentationAction<WorkoutCompletedFeature.Action>)
         case binding(BindingAction<State>)
+        case loadUserDefault
+        case loadUserDefaultResult(Result<OnboardingUserInfoModel, Error>)
     }
 
     var body: some ReducerOf<Self> {
@@ -52,12 +55,9 @@ struct SettingFeature {
             switch action {
             case .onAppear:
                 state.hideTabBar = false
-                if let onbarodingUserInfoModel = UserDefaultsManager().loadOnboardingUserInfo() {
-                    state.onboardingUserInfoModel = onbarodingUserInfoModel
-                }
-                
-                return .merge(.send(.getRecentDayWorkouts),
-                              .send(.getCompletedDates))
+                return .concatenate(.send(.loadUserDefault),
+                                    .send(.getRecentDayWorkouts),
+                                    .send(.getCompletedDates))
             case .getRecentDayWorkouts:
                 return .run { send in
                     do {
@@ -87,7 +87,9 @@ struct SettingFeature {
             case let .path(action):
                 switch action {
                 case .element(id: _, action: .myPage(let .didTapModifyProfileButton(onboardingUserInfoModel))):
-                    state.path.append(.modifyProfile(ModifyProfileFeature.State(onboardingUserInfoModel: onboardingUserInfoModel)))
+                    if let onboardingUserInfoModel = onboardingUserInfoModel {
+                        state.path.append(.modifyProfile(ModifyProfileFeature.State(onboardingUserInfoModel: onboardingUserInfoModel)))
+                    }
                     return .none
                 case .element(id: _, action: .myPage(let .didTapInfoButton(userInfoType))):
                     switch userInfoType {
@@ -97,12 +99,12 @@ struct SettingFeature {
                         state.path.append(.modifyWeight(ModifyWeightFeature.State()))
                         return .none
                     case .level:
-                        if let onboardingUserInfoModel = state.onboardingUserInfoModel {
+                        if let onboardingUserInfoModel = userDefaultsAPIClient.loadOnboardingUserInfo() {
                             state.path.append(.modifyLevel(LevelSelectFeature.State(onboardingUserModel: onboardingUserInfoModel, entryType: .modify)))
                         }
                         return .none
                     case .method:
-                        if let onboardingUserInfoModel = state.onboardingUserInfoModel {
+                        if let onboardingUserInfoModel = userDefaultsAPIClient.loadOnboardingUserInfo() {
                             state.path.append(.modifyMethod(MethodSelectFeature.State(onboardingUserModel: onboardingUserInfoModel, entryType: .modify)))
                         }
                         return .none
@@ -111,12 +113,25 @@ struct SettingFeature {
                     return .none
                 }
             case .didTapMyPage:
-                state.path.append(.myPage(MyPageFeature.State()))
+                if let onboardingUserInfoModel = state.onboardingUserInfoModel {
+                    state.path.append(.myPage(MyPageFeature.State(onboardingUserInfoModel: onboardingUserInfoModel)))
+                }
                 return .none
             case let .didTapMyActivity(workout):
                 state.completedState = WorkoutCompletedFeature.State(item: workout)
                 return .none
             case .completedAction(.presented(.didTapCloseButton)):
+                return .none
+            case .loadUserDefault:
+                return .run { send in
+                    if let result = userDefaultsAPIClient.loadOnboardingUserInfo() {
+                        await send(.loadUserDefaultResult(.success(result)))
+                    } else {
+                        await send(.loadUserDefaultResult(.failure(UserDefaultsError.emptyData)))
+                    }
+                }
+            case .loadUserDefaultResult(.success(let userInfo)):
+                state.onboardingUserInfoModel = userInfo
                 return .none
             default:
                 return .none
@@ -203,4 +218,9 @@ struct SettingView: View {
     SettingView(store: Store(initialState: SettingFeature.State()){
         SettingFeature()
     })
+}
+
+
+enum UserDefaultsError: Error {
+    case emptyData
 }

--- a/TodayWod/Features/Setting/SettingFeature.swift
+++ b/TodayWod/Features/Setting/SettingFeature.swift
@@ -219,8 +219,3 @@ struct SettingView: View {
         SettingFeature()
     })
 }
-
-
-enum UserDefaultsError: Error {
-    case emptyData
-}

--- a/TodayWod/InternalStorage/UserDefaults/UserDefaultsError.swift
+++ b/TodayWod/InternalStorage/UserDefaults/UserDefaultsError.swift
@@ -1,0 +1,12 @@
+//
+//  UserDefaultsError.swift
+//  TodayWod
+//
+//  Created by Davidyoon on 11/11/24.
+//
+
+import Foundation
+
+enum UserDefaultsError: Error {
+    case emptyData
+}

--- a/TodayWod/StorageClient/UserDefaultsClient.swift
+++ b/TodayWod/StorageClient/UserDefaultsClient.swift
@@ -8,15 +8,15 @@
 import Foundation
 import ComposableArchitecture
 
-struct UserDefaultsAPIClient {
+struct UserDefaultsClient {
     var saveOnboardingUserInfo: @Sendable (_ onboadingModel: OnboardingUserInfoModel) -> Void
     var loadOnboardingUserInfo: @Sendable () -> OnboardingUserInfoModel?
     var checkUserInfoExists: @Sendable () -> Bool
 }
 
-extension UserDefaultsAPIClient: DependencyKey {
+extension UserDefaultsClient: DependencyKey {
 
-    static var liveValue: UserDefaultsAPIClient = .init(saveOnboardingUserInfo: { model in
+    static var liveValue: UserDefaultsClient = .init(saveOnboardingUserInfo: { model in
         let userDefaultsManager = UserDefaultsManager()
         userDefaultsManager.saveOnboardingUserInfo(data: model)
     }, loadOnboardingUserInfo: {
@@ -31,9 +31,9 @@ extension UserDefaultsAPIClient: DependencyKey {
 
 extension DependencyValues {
 
-    var userDefaultsAPIClient: UserDefaultsAPIClient {
-        get { self[UserDefaultsAPIClient.self] }
-        set { self[UserDefaultsAPIClient.self] = newValue }
+    var userDefaultsClient: UserDefaultsClient {
+        get { self[UserDefaultsClient.self] }
+        set { self[UserDefaultsClient.self] = newValue }
     }
 
 }


### PR DESCRIPTION
* 레벨, 운동 방식 수정 시 기존 선택한 방식은 선택하지 못하도록 로직 수정
* UserDefaultsAPIClient 선행 처리로 상위 PR 231 이후로 머지 
* [TOW-191](https://davidyoon1122.atlassian.net/browse/TOW-191?atlOrigin=eyJpIjoiMWZkYWY0MDAwM2Q2NDIxOTg0MTBkOGRiNDBjMmYyYTciLCJwIjoiaiJ9)
* @jiyeonO onboardingUserInfoModel 불러오는 방식 같이 고민해 보아야 할 것 같아서 글 남깁니다.
1. 옵셔널로 state 로 넣어두어 onAppear에서 처리 할지?
- onAppear 액션와 UserDefaults로 onboardingUserInfoModel이 업데이트가 필요한 곳에서 API로 업데이트 후 사용
3. UserDefaultsAPIClient로 계속 호출하여 사용할지? 
- state에 onboardingUserInfoModel 선언하지 않고 API 호출로 계속 불러와 사용하는 방식