### PR TITLE
[TOW-271][iOS][BugFix] iOS16 대응 스플레쉬 안넘어가는 현상 수정

### DIFF
--- a/TodayWod/Features/Home/WorkOut/Detail/WorkOutDetailFeature.swift
+++ b/TodayWod/Features/Home/WorkOut/Detail/WorkOutDetailFeature.swift
@@ -358,19 +358,23 @@ struct WorkOutDetailView: View {
             }
             .toolbar(.hidden, for: .navigationBar)
             .sheet(item: $store.scope(state: \.confirmState, action: \.confirmAction)) { conirmationStore in
-                WorkoutConfirmationView(store: conirmationStore)
-                    .measureHeight { height in
-                        store.send(.setConfirmationViewDynamicHeight(height))
-                    }
-                    .presentationDetents([.height(store.state.confirmationViewDynamicHeight + 20.0)])
+                WithPerceptionTracking {
+                    WorkoutConfirmationView(store: conirmationStore)
+                        .measureHeight { height in
+                            store.send(.setConfirmationViewDynamicHeight(height))
+                        }
+                        .presentationDetents([.height(store.state.confirmationViewDynamicHeight + 20.0)])
+                }
             }
             .sheet(item: $store.scope(state: \.breakTimerSettingsState, action: \.breakTimerSettingsAction)) { breakTimerSettingsStore in
-                BreakTimerSettingsView(store: breakTimerSettingsStore)
-                    .measureHeight { height in
-                        store.send(.setBreakTimerSettingsViewDynamicHeight(height))
-                    }
-                    .presentationDetents([.height(store.state.breakTimerSettingsViewDynamicHeight)])
-                    .sheetBackground(.clear)
+                WithPerceptionTracking {
+                    BreakTimerSettingsView(store: breakTimerSettingsStore)
+                        .measureHeight { height in
+                            store.send(.setBreakTimerSettingsViewDynamicHeight(height))
+                        }
+                        .presentationDetents([.height(store.state.breakTimerSettingsViewDynamicHeight)])
+                        .sheetBackground(.clear)
+                }
             }
             .alert($store.scope(state: \.alert, action: \.alert))
             .onAppear {

--- a/TodayWod/Features/Home/WorkOut/Main/WorkOutFeature.swift
+++ b/TodayWod/Features/Home/WorkOut/Main/WorkOutFeature.swift
@@ -240,21 +240,24 @@ struct WorkOutView: View {
                     }
                 }
             } destination: { store in
-                switch store.case {
-                case let .detail(store):
-                    WorkOutDetailView(store: store)
-                case let .completed(store):
-                    WorkoutCompletedView(store: store)
+                WithPerceptionTracking {
+                    switch store.case {
+                    case let .detail(store):
+                        WorkOutDetailView(store: store)
+                    case let .completed(store):
+                        WorkoutCompletedView(store: store)
+                    }
                 }
-                
             }
             .toolbar(.hidden, for: .navigationBar)
             .sheet(item: $store.scope(state: \.celebrateState, action: \.celebrateAction)) { celebrateStore in
-                CelebrateView(store: celebrateStore)
-                    .measureHeight { height in
-                        store.send(.setDynamicHeight(height))
-                    }
-                    .presentationDetents([.height(store.state.dynamicHeight + 20.0)])
+                WithPerceptionTracking {
+                    CelebrateView(store: celebrateStore)
+                        .measureHeight { height in
+                            store.send(.setDynamicHeight(height))
+                        }
+                        .presentationDetents([.height(store.state.dynamicHeight + 20.0)])
+                }
             }
             .alert($store.scope(state: \.alert, action: \.alert))
             .toastView(toast: $store.toast.sending(\.setToast))

--- a/TodayWod/Features/Home/WorkOut/Main/WorkOutListFeature.swift
+++ b/TodayWod/Features/Home/WorkOut/Main/WorkOutListFeature.swift
@@ -51,7 +51,7 @@ struct WorkOutListFeature {
             case .dayModelsResult(.success(let result)):
                 state.dayWorkouts = result
                 return .none
-            case .dayModelsResult(.failure(let error)):
+            case .dayModelsResult(.failure(_)):
                 // TODO: - 에러 표시 여기서
                 state.dayWorkouts = []
                 return .none

--- a/TodayWod/Features/Onboarding/Gender/GenderSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Gender/GenderSelectFeature.swift
@@ -171,17 +171,19 @@ struct GenderSelectView: View {
                     }
                 }
             } destination: { store in
-                switch store.case {
-                case let .nickName(store):
-                    NicknameInputView(store: store)
-                case let .height(store):
-                    HeightInputView(store: store)
-                case let .weight(store):
-                    WeightInputView(store: store)
-                case let .level(store):
-                    LevelSelectView(store: store)
-                case let .method(store):
-                    MethodSelectView(store: store)
+                WithPerceptionTracking {
+                    switch store.case {
+                    case let .nickName(store):
+                        NicknameInputView(store: store)
+                    case let .height(store):
+                        HeightInputView(store: store)
+                    case let .weight(store):
+                        WeightInputView(store: store)
+                    case let .level(store):
+                        LevelSelectView(store: store)
+                    case let .method(store):
+                        MethodSelectView(store: store)
+                    }
                 }
             }
         }

--- a/TodayWod/Features/Onboarding/Level/LevelSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Level/LevelSelectFeature.swift
@@ -103,7 +103,7 @@ struct LevelSelectFeature {
                 state.onCelebrate = false
                 
                 return .run { _ in
-                    try await wodClient.removePrograms()
+                    try wodClient.removePrograms()
                     await dismiss()
                 }
             case let .setLevel(level):

--- a/TodayWod/Features/Onboarding/Method/MethodSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Method/MethodSelectFeature.swift
@@ -107,7 +107,7 @@ struct MethodSelectFeature {
                 state.onCelebrate = false
                 
                 return .run { _ in
-                    try await wodClient.removePrograms()
+                    try wodClient.removePrograms()
                     await dismiss()
                 }
             case let .setMethod(methodType):

--- a/TodayWod/Features/Onboarding/SocialLogin/SocialLoginFeature.swift
+++ b/TodayWod/Features/Onboarding/SocialLogin/SocialLoginFeature.swift
@@ -33,7 +33,7 @@ struct SocialLoginFeature {
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
-            case .alert(.presented(.moveToTabView(let userModel))):
+            case .alert(.presented(.moveToTabView(_))):
                 // TODO: - 로그인 기능 추가 될 시 유저 정보 데이터 가져와서 확인 후 처리하는 로직 추가
                 
                 state.path.append(AppFeature.State())
@@ -173,7 +173,9 @@ struct SocialLoginView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Colors.blue60.swiftUIColor)
             } destination: { store in
-                AppTabView(store: store)
+                WithPerceptionTracking {
+                    AppTabView(store: store)
+                }
             }
         }
     }

--- a/TodayWod/Features/Root/TodayWod.swift
+++ b/TodayWod/Features/Root/TodayWod.swift
@@ -66,18 +66,20 @@ struct TodayWodView: View {
     let store: StoreOf<TodayWod>
 
     var body: some View {
-        switch store.state {
-        case .splash:
-            if let store = store.scope(state: \.splash, action: \.splash) {
-                SplashView(store: store)
-            }
-        case .app:
-            if let store = store.scope(state: \.app, action: \.app) {
-                AppTabView(store: store)
-            }
-        case .onBoarding:
-            if let store = store.scope(state: \.onBoarding, action: \.onBoarding) {
-                GenderSelectView(store: store)
+        WithPerceptionTracking {
+            switch store.state {
+            case .splash:
+                if let store = store.scope(state: \.splash, action: \.splash) {
+                    SplashView(store: store)
+                }
+            case .app:
+                if let store = store.scope(state: \.app, action: \.app) {
+                    AppTabView(store: store)
+                }
+            case .onBoarding:
+                if let store = store.scope(state: \.onBoarding, action: \.onBoarding) {
+                    GenderSelectView(store: store)
+                }
             }
         }
     }

--- a/TodayWod/Features/Setting/MyPage/VersionInfo/VersionInfoFeature.swift
+++ b/TodayWod/Features/Setting/MyPage/VersionInfo/VersionInfoFeature.swift
@@ -49,7 +49,7 @@ struct VersionInfoFeature {
                     state.shouldUpdate = result > currentVersion
                 }
                 return .none
-            case .versionRequestResult(.failure(let error)):
+            case .versionRequestResult(.failure(_)):
                 state.versionInfo = ""
                 return .none
             }

--- a/TodayWod/Features/Setting/SettingFeature.swift
+++ b/TodayWod/Features/Setting/SettingFeature.swift
@@ -200,17 +200,19 @@ struct SettingView: View {
                     store.send(.onAppear)
                 }
             } destination: { store in
-                switch store.case {
-                case let .myPage(store):
-                    MyPageView(store: store)
-                case let .modifyProfile(store):
-                    ModifyProfileView(store: store)
-                case let .modifyWeight(store):
-                    ModifyWeightView(store: store)
-                case let .modifyLevel(store):
-                    LevelSelectView(store: store)
-                case let .modifyMethod(store):
-                    MethodSelectView(store: store)
+                WithPerceptionTracking {
+                    switch store.case {
+                    case let .myPage(store):
+                        MyPageView(store: store)
+                    case let .modifyProfile(store):
+                        ModifyProfileView(store: store)
+                    case let .modifyWeight(store):
+                        ModifyWeightView(store: store)
+                    case let .modifyLevel(store):
+                        LevelSelectView(store: store)
+                    case let .modifyMethod(store):
+                        MethodSelectView(store: store)
+                    }
                 }
             }
             .fullScreenCover(item: $store.scope(state: \.completedState, action: \.completedAction)) { store in


### PR DESCRIPTION
- [TOW-271](https://davidyoon1122.atlassian.net/browse/TOW-271?atlOrigin=eyJpIjoiM2UyNzY0YjgwOGJmNDJiNzg0NTc0NGM1MWQyNTFkMmEiLCJwIjoiaiJ9)

## 발생 내용
- iOS16에서 스플래쉬 이후 화면(회원가입)으로 넘어가지 않는 현상
- iOS16.2 시뮬레이터에서도 재현 발생
- 빌드에러가 발생하는 곳에 `WithPerceptionTracking` 추가
- 빌드 에러 이외에도 경고 문구 발생하는 위치에 모두 `WithPerceptionTracking` 추가 처리 완료

## WithPerceptionTracking
- [document](https://swiftpackageindex.com/pointfreeco/swift-perception/1.3.5/documentation/perception/withperceptiontracking(_:onchange:))
- 상태 변경 시 View Update를 보장해주는 역할 (Perceptible() models를 구독하도록 함)
- sheet 띄우는 등의 navigation 처리 할 때도 사용 필요
    - `GeometryReader`, `ScrollViewReader`, `LazyVStack`, `LazyVGrid`, `sheet`, `popover`, `fullScreenCover`, `navigationDestination`

## 에러 문구
```swift
// 콘솔에러 (이건 계속 발생)
[Security] This method should not be called on the main thread as it may lead to UI unresponsiveness
```
```swift
// 빌드에러
Perceptible state was accessed but is not being tracked. Track changes to state by wrapping your view in a 'WithPerceptionTracking' view. This must also be done for any escaping, trailing closures, such as 'GeometryReader', `LazyVStack` (and all lazy views), navigation APIs ('sheet', 'popover', 'fullScreenCover', etc.), and others.
```