### PR TITLE
[TOW-274] Other Linker Flag 추가

### DIFF
--- a/TodayWod.xcodeproj/project.pbxproj
+++ b/TodayWod.xcodeproj/project.pbxproj
@@ -1621,6 +1621,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tow.TodayWod;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1665,6 +1666,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tow.TodayWod;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
* Firebase 데이터 수집 안되어 Other Linker Flag 추가

* Firebase 설정 후 데이터 수집 안되는 이슈

로그
11.4.0 - [FirebaseCore][I-COR000033] Data Collection flag is not set.
https://stackoverflow.com/questions/51376990/firebase-corei-cor000022-firebase-analytics-is-not-available
원인
Firebase를 cocoapod이 아닌 형태로 설치 했을 때 발생
해결방법
Other Linker Flag 에 -ObjC 추가