### PR TITLE
[TOW-279][iOS] 천지인 키보드 입력 불가 이슈 수정

### DIFF
--- a/TodayWod/Extensions/Extension+String.swift
+++ b/TodayWod/Extensions/Extension+String.swift
@@ -34,7 +34,7 @@ extension String {
     }
     
     func filteredNickName() -> String {
-        let regex = "^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]*$"
+        let regex = "^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣㆍ]*$"
                         
         if let _ = self.range(of: regex, options: .regularExpression) {
             return "\(self.prefix(Constants.nickNameMaxLength))"


### PR DESCRIPTION
- 원인 : 천지인 키보드 아래하가 필터 처리되어 입력 불가 이슈 발생
- 수정 내용 : 필터 처리되던 천지인 키보드 아래하 Regex 추가
- [TOW-279](https://davidyoon1122.atlassian.net/browse/TOW-279?atlOrigin=eyJpIjoiNDRlZDNlMGUwZjYwNGQwZTk0ZDZlMTFlNDdkYTQ3MmUiLCJwIjoiaiJ9)