### PR TITLE
[TOW-279][iOS] 천지인 키보드 입력 불가 이슈 추가 수정

### DIFF
--- a/TodayWod.xcodeproj/project.pbxproj
+++ b/TodayWod.xcodeproj/project.pbxproj
@@ -1620,7 +1620,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.3;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tow.TodayWod;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1665,7 +1665,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.3;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tow.TodayWod;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/TodayWod/Extensions/Extension+String.swift
+++ b/TodayWod/Extensions/Extension+String.swift
@@ -34,7 +34,7 @@ extension String {
     }
     
     func filteredNickName() -> String {
-        let regex = "^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣㆍ]*$"
+        let regex = "^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ\\u1100-\\u1112\\u318D\\u119E\\u11A2\\u2022\\u2025\\u00B7\\uFE55\\s]*$"
                         
         if let _ = self.range(of: regex, options: .regularExpression) {
             return "\(self.prefix(Constants.nickNameMaxLength))"


### PR DESCRIPTION
- 원인 : 아래하가 두번 쓰이는 경우에 대한 로직 처리 부족
- 수정 방법 : 유니코드 추가로 해결
- [TOW-279](https://davidyoon1122.atlassian.net/browse/TOW-279?atlOrigin=eyJpIjoiMzdlMjUxOTg2M2Y4NGZlM2FmYWUxMGNlMzc3NzI1ZWMiLCJwIjoiaiJ9)