### PR TITLE
[TOW-280] 닉네임 천지인 키보드 빈 문자열 발생, 온보딩 성별 선택 0.3초 딜레이 중 여러번의 액션 이러는 이슈

### DIFF
--- a/TodayWod/Extensions/Extension+String.swift
+++ b/TodayWod/Extensions/Extension+String.swift
@@ -34,7 +34,9 @@ extension String {
     }
     
     func filteredNickName() -> String {
-        let regex = "^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ\\u1100-\\u1112\\u318D\\u119E\\u11A2\\u2022\\u2025\\u00B7\\uFE55\\s]*$"
+        guard !self.isEmpty else { return "" }
+        
+        let regex = "^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ\\u1100-\\u1112\\u318D\\u119E\\u11A2\\u2022\\u2025\\u00B7\\uFE55]*$"
                         
         if let _ = self.range(of: regex, options: .regularExpression) {
             return "\(self.prefix(Constants.nickNameMaxLength))"

--- a/TodayWod/Features/Onboarding/Gender/GenderSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Gender/GenderSelectFeature.swift
@@ -27,17 +27,15 @@ struct GenderSelectFeature {
         var gender: GenderType? = nil
         var path = StackState<Path.State>()
         var onboardingUserModel: OnboardingUserInfoModel = .init()
+        var isProcessing: Bool = false
     }
     
     enum Action {
+        case onAppear
         case setGender(GenderType)
         case path(StackActionOf<Path>)
         case toNickname
         case finishOnboarding
-    }
-
-    enum ThrottleID: Hashable {
-        case throttle
     }
 
     @Dependency(\.continuousClock) var clock
@@ -45,7 +43,13 @@ struct GenderSelectFeature {
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .onAppear:
+                state.isProcessing = false
+                return .none
             case let .setGender(genderType):
+                guard !state.isProcessing else { return .none }
+
+                state.isProcessing = true
                 state.gender = genderType
                 state.onboardingUserModel.gender = genderType
                 let generator = UIImpactFeedbackGenerator(style: .medium)
@@ -53,12 +57,6 @@ struct GenderSelectFeature {
                 generator.impactOccurred()
 
                 return .send(.toNickname)
-                    .throttle(
-                        id: ThrottleID.throttle,
-                        for: 0.5,
-                        scheduler: DispatchQueue.main,
-                        latest: false
-                    )
             case let .path(action):
                 switch action {
                 case .element(id: _, action: .nickName(.finishInputNickname(let heightState))):
@@ -162,7 +160,8 @@ struct GenderSelectView: View {
                                     .clipShape(.circle)
                                     .opacity(store.gender == .man ? 1.0 : 0.6)
                             })
-                            
+                            .disabled(store.isProcessing)
+
                             Button(action: {
                                 store.send(.setGender(.woman))
                             }, label: {
@@ -172,10 +171,14 @@ struct GenderSelectView: View {
                                     .clipShape(.circle)
                                     .opacity(store.gender == .woman ? 1.0 : 0.6)
                             })
+                            .disabled(store.isProcessing)
                         }
                         .padding(.top, 80.0)
                         .padding(.horizontal)
                     }
+                }
+                .onAppear {
+                    store.send(.onAppear)
                 }
             } destination: { store in
                 WithPerceptionTracking {

--- a/TodayWod/Features/Onboarding/Gender/GenderSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Gender/GenderSelectFeature.swift
@@ -36,7 +36,7 @@ struct GenderSelectFeature {
         case finishOnboarding
     }
 
-    enum ID: Hashable {
+    enum ThrottleID: Hashable {
         case throttle
     }
 
@@ -52,16 +52,13 @@ struct GenderSelectFeature {
                 generator.prepare()
                 generator.impactOccurred()
 
-                return .run(operation: { send in
-                    try await clock.sleep(for: .seconds(0.3))
-                    await send(.toNickname)
-                })
-                .throttle(
-                    id: ID.throttle,
-                    for: 0.5,
-                    scheduler: DispatchQueue.main,
-                    latest: true
-                )
+                return .send(.toNickname)
+                    .throttle(
+                        id: ThrottleID.throttle,
+                        for: 0.5,
+                        scheduler: DispatchQueue.main,
+                        latest: false
+                    )
             case let .path(action):
                 switch action {
                 case .element(id: _, action: .nickName(.finishInputNickname(let heightState))):

--- a/TodayWod/Features/Onboarding/Gender/GenderSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Gender/GenderSelectFeature.swift
@@ -35,7 +35,11 @@ struct GenderSelectFeature {
         case toNickname
         case finishOnboarding
     }
-    
+
+    enum ID: Hashable {
+        case debounce, throttle
+    }
+
     @Dependency(\.continuousClock) var clock
     
     var body: some ReducerOf<Self> {
@@ -52,6 +56,12 @@ struct GenderSelectFeature {
                     try await clock.sleep(for: .seconds(0.3))
                     await send(.toNickname)
                 })
+                .throttle(
+                    id: ID.throttle,
+                    for: 0.5,
+                    scheduler: DispatchQueue.main,
+                    latest: true
+                )
             case let .path(action):
                 switch action {
                 case .element(id: _, action: .nickName(.finishInputNickname(let heightState))):

--- a/TodayWod/Features/Onboarding/Gender/GenderSelectFeature.swift
+++ b/TodayWod/Features/Onboarding/Gender/GenderSelectFeature.swift
@@ -37,7 +37,7 @@ struct GenderSelectFeature {
     }
 
     enum ID: Hashable {
-        case debounce, throttle
+        case throttle
     }
 
     @Dependency(\.continuousClock) var clock


### PR DESCRIPTION
* 닉네임 천지인 키보드 빈 문자열 발생하여 앱 크래쉬 현상 처리
* 닉네임 공백 허용 regex 제거
* 온보딩 성별 선택 0.3초 딜레이 중 여러번의 액션 이러는 이슈 처리 -> throttle 처리
* [TOW-280](https://davidyoon1122.atlassian.net/browse/TOW-280?atlOrigin=eyJpIjoiYWFjOTJmZDhlNzFkNDA1Zjg3M2M5YzkzNzhiMDA4NGUiLCJwIjoiaiJ9)